### PR TITLE
Add a bytecode-only target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [unreleased]
 
 - Compile with `-safe-string` (issue #1)
+- Add a bytecode-only target (PR #2)
 
 ## v0.1.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 PACKAGE=enumerators
 SOURCES=32/beint.ml 32/beint.mli 64/beint.ml 64/beint.mli enumerator.ml enumerator.mli enumerators.mllib
 TESTS=tests.ml
-TARGET_NAMES=enumerator.cmi $(PACKAGE).cma $(PACKAGE).cmxa $(PACKAGE).a
+TARGET_NAMES=enumerator.cmi $(PACKAGE).cma
+NATIVE_TARGET_NAMES=$(PACKAGE).cmxa $(PACKAGE).a
 TARGETS=$(addprefix _build/, $(TARGET_NAMES))
+NATIVE_TARGETS=$(addprefix _build/, $(NATIVE_TARGET_NAMES))
 
-.PHONY: all check check_coverage check_coverage_html install uninstall clean
+.PHONY: all byte opt check check_coverage check_coverage_html install uninstall clean
 
-all: $(TARGETS)
+all: byte opt
+
+byte: $(TARGETS)
+
+opt: $(NATIVE_TARGETS)
 
 _build/%: $(SOURCES)
 	ocamlbuild -use-ocamlfind $*
@@ -25,7 +31,7 @@ check_coverage_html:
 	rm -f bisect*.out
 
 install: uninstall
-	ocamlfind install $(PACKAGE) $(TARGETS) META
+	ocamlfind install $(PACKAGE) META $(TARGETS) -optional $(NATIVE_TARGETS)
 
 uninstall:
 	ocamlfind remove $(PACKAGE)

--- a/opam
+++ b/opam
@@ -5,7 +5,10 @@ homepage: "https://github.com/cryptosense/enumerators"
 bug-reports: "https://github.com/cryptosense/enumerators/issues"
 license: "BSD-2"
 dev-repo: "https://github.com/cryptosense/enumerators.git"
-build: [make]
+build: [
+    [make] {ocaml-native}
+    [make "byte"] {!ocaml-native}
+]
 install: [make "install"]
 build-test: [make "check"]
 remove: ["ocamlfind" "remove" "enumerators"]


### PR DESCRIPTION
Some environments do not support native compilation.

This adds a "make byte" target that only builds a bytecode library.

This target is automatically selected by opam when the variable `ocaml-native` is false.

:sparkles: Thanks! :sparkles:
